### PR TITLE
bugfix: Use current UI settings to test PTT

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -3200,8 +3200,10 @@ void Configuration::impl::on_test_PTT_push_button_clicked (bool checked)
       return;
     }
 
-  if (open_rig ())
+  if (rig_active_)
     {
+      // Update the data mode from the UI before testing PTT
+      data_mode_ = static_cast<DataMode> (ui_->TX_mode_button_group->checkedId ());
       Q_EMIT self_->transceiver_ptt (checked);
     }
 }


### PR DESCRIPTION
Is it too late to sneak in a UI bugfix for the 2.3.0 release?

This was driving me nuts when trying to use FM `PKT` mode on my Yaesu FT-817ND. The `Test PTT` button kept switching the radio back to `DIG` mode, but when `TX`ing the radio it was able to transmit correctly using `PKT`. After reading the [rather lengthy Readme in Configuration.cpp](https://github.com/js8call/js8call/blob/8260745ce556794882e86b08edbcc370d4850bcd/Configuration.cpp#L4) I understand why the code doesn't "save" the configuration settings until the `OK` button is pressed, but errors such as this are created as a result.