### PR TITLE
Schedule Fixes & Enhancements

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -2715,7 +2715,6 @@ void Configuration::impl::accept ()
             << "reset o/p:" << restart_sound_output_device_
             << "reset n:" << restart_notification_sound_output_device_;
 
-  auto_switch_bands_ = ui_->auto_switch_bands_check_box->isChecked();
   my_callsign_ = ui_->callsign_line_edit->text ().toUpper().trimmed();
   my_grid_ = ui_->grid_line_edit->text ().toUpper().trimmed();
   my_groups_ = splitGroups(ui_->groups_line_edit->text().toUpper().trimmed(), true);
@@ -2769,6 +2768,15 @@ void Configuration::impl::accept ()
   ptt_command_ = ui_->ptt_command_line_edit->text();
   aprs_server_name_ = ui_->aprs_server_line_edit->text();
   aprs_server_port_ = ui_->aprs_server_port_spin_box->value();
+
+  auto const newAutoSwitchBands = ui_->auto_switch_bands_check_box->isChecked();
+
+  if(newAutoSwitchBands != auto_switch_bands_)
+  {
+	  auto_switch_bands_ = newAutoSwitchBands;
+
+	  Q_EMIT self_->auto_switch_bands_changed(auto_switch_bands_);
+  }
 
   auto const newUdpEnabled    = ui_->udpEnable->isChecked();
   auto const newUdpServerName = ui_->udp_server_line_edit->text ();

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -3496,13 +3496,13 @@ void Configuration::impl::hop_to_station ()
 
 void Configuration::impl::delete_stations ()
 {
-	auto selection_model = ui_->stations_table_view->selectionModel ();
-	selection_model->select (selection_model->selection (), QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
-	next_stations_.removeDisjointRows (selection_model->selectedRows ());
-	ui_->stations_table_view->resizeColumnToContents (StationList::band_column);
-	ui_->stations_table_view->resizeColumnToContents (StationList::frequency_column);
-	ui_->stations_table_view->resizeColumnToContents (StationList::switch_at_column);
-	ui_->stations_table_view->resizeColumnToContents (StationList::switch_until_column);
+  auto selection_model = ui_->stations_table_view->selectionModel ();
+  selection_model->select (selection_model->selection (), QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
+  next_stations_.removeDisjointRows (selection_model->selectedRows ());
+  ui_->stations_table_view->resizeColumnToContents (StationList::band_column);
+  ui_->stations_table_view->resizeColumnToContents (StationList::frequency_column);
+  ui_->stations_table_view->resizeColumnToContents (StationList::switch_at_column);
+  ui_->stations_table_view->resizeColumnToContents (StationList::switch_until_column);
 }
 
 void Configuration::impl::insert_station ()

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -2592,8 +2592,6 @@ void Configuration::impl::accept ()
   // parameters so extract values from models and make them live
   //
 
-  auto_switch_bands_ = ui_->auto_switch_bands_check_box->isChecked();
-
   if (next_font_ != font_)
     {
       font_ = next_font_;
@@ -2717,6 +2715,7 @@ void Configuration::impl::accept ()
             << "reset o/p:" << restart_sound_output_device_
             << "reset n:" << restart_notification_sound_output_device_;
 
+  auto_switch_bands_ = ui_->auto_switch_bands_check_box->isChecked();
   my_callsign_ = ui_->callsign_line_edit->text ().toUpper().trimmed();
   my_grid_ = ui_->grid_line_edit->text ().toUpper().trimmed();
   my_groups_ = splitGroups(ui_->groups_line_edit->text().toUpper().trimmed(), true);

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -2592,6 +2592,8 @@ void Configuration::impl::accept ()
   // parameters so extract values from models and make them live
   //
 
+  auto_switch_bands_ = ui_->auto_switch_bands_check_box->isChecked();
+
   if (next_font_ != font_)
     {
       font_ = next_font_;
@@ -2715,7 +2717,6 @@ void Configuration::impl::accept ()
             << "reset o/p:" << restart_sound_output_device_
             << "reset n:" << restart_notification_sound_output_device_;
 
-  auto_switch_bands_ = ui_->auto_switch_bands_check_box->isChecked();
   my_callsign_ = ui_->callsign_line_edit->text ().toUpper().trimmed();
   my_grid_ = ui_->grid_line_edit->text ().toUpper().trimmed();
   my_groups_ = splitGroups(ui_->groups_line_edit->text().toUpper().trimmed(), true);

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -1483,6 +1483,11 @@ Configuration::impl::impl (Configuration * self, QDir const& temp_directory,
   ui_->stations_table_view->sortByColumn (StationList::switch_at_column, Qt::AscendingOrder);
   connect(ui_->auto_switch_bands_check_box, &QCheckBox::clicked, ui_->stations_table_view, &QTableView::setEnabled);
 
+  // Immediately emit the auto switch band change signal to kick the scheduler without having to potentially save twice
+  connect(ui_->auto_switch_bands_check_box, &QCheckBox::clicked, this, [this](bool auto_switch_bands) {
+	  Q_EMIT self_->auto_switch_bands_changed(auto_switch_bands);
+  });
+
   // delegates
   auto stations_item_delegate = new QStyledItemDelegate {this};
   stations_item_delegate->setItemEditorFactory (item_editor_factory ());
@@ -1523,7 +1528,7 @@ Configuration::impl::impl (Configuration * self, QDir const& temp_directory,
 
 
 
-	enumerate_rigs ();
+  enumerate_rigs ();
   initialize_models ();
 
   audio_input_device_               = next_audio_input_device_;

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -1516,7 +1516,7 @@ Configuration::impl::impl (Configuration * self, QDir const& temp_directory,
   // Connect to selection changes and update action states
   auto selection_model = ui_->stations_table_view->selectionModel();
   connect(selection_model, &QItemSelectionModel::selectionChanged,
-	this, [this](const QItemSelection &selected, const QItemSelection &) {
+	this, [this]() {
     auto selected_rows = ui_->stations_table_view->selectionModel()->selectedRows();
     bool has_selection = !selected_rows.isEmpty();
     bool has_single_selection = (selected_rows.size() == 1);

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -1517,9 +1517,12 @@ Configuration::impl::impl (Configuration * self, QDir const& temp_directory,
   auto selection_model = ui_->stations_table_view->selectionModel();
   connect(selection_model, &QItemSelectionModel::selectionChanged,
 	this, [this](const QItemSelection &selected, const QItemSelection &) {
-	bool has_selection = !selected.isEmpty();
-	station_hop_action_->setVisible(has_selection);
+    auto selected_rows = ui_->stations_table_view->selectionModel()->selectedRows();
+    bool has_selection = !selected_rows.isEmpty();
+    bool has_single_selection = (selected_rows.size() == 1);
+
 	station_delete_action_->setVisible(has_selection);
+    station_hop_action_->setVisible(has_single_selection);
   });
 
   // Initial state
@@ -2797,13 +2800,11 @@ void Configuration::impl::accept ()
   aprs_server_port_ = ui_->aprs_server_port_spin_box->value();
 
   auto const newAutoSwitchBands = ui_->auto_switch_bands_check_box->isChecked();
+  auto_switch_bands_ = newAutoSwitchBands;
 
-  if(newAutoSwitchBands != auto_switch_bands_)
-  {
-	  auto_switch_bands_ = newAutoSwitchBands;
-
-	  Q_EMIT self_->auto_switch_bands_changed(auto_switch_bands_);
-  }
+  // Emit this even if the value has not changed as a way to reset the scheduler.
+  // TODO this is smelly, revisit when we make the scheduler smarter
+  Q_EMIT self_->auto_switch_bands_changed(auto_switch_bands_);
 
   auto const newUdpEnabled    = ui_->udpEnable->isChecked();
   auto const newUdpServerName = ui_->udp_server_line_edit->text ();

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -322,7 +322,7 @@ public:
   Q_SIGNAL void auto_switch_bands_changed (bool auto_switch_bands);
 
   // This signal is emitted when the user requests a manual station hop
-  Q_SIGNAL void manual_band_hop_requested (StationList::Station const& station);
+  Q_SIGNAL void manual_band_hop_requested (StationList::Station const station);
 
   //
   // These signals are emitted and reflect transceiver state changes

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -317,6 +317,9 @@ public:
   // This signal is emitted when the band schedule changes
   Q_SIGNAL void band_schedule_changed (StationList &stations);
 
+  // This signal is emitted when the auto switch bands choice changes
+  Q_SIGNAL void auto_switch_bands_changed (bool auto_switch_bands);
+
   //
   // These signals are emitted and reflect transceiver state changes
   //

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -7,6 +7,7 @@
 #include "Radio.hpp"
 #include "IARURegions.hpp"
 #include "AudioDevice.hpp"
+#include "StationList.hpp"
 #include "Transceiver.hpp"
 
 #include "pimpl_h.hpp"
@@ -319,6 +320,9 @@ public:
 
   // This signal is emitted when the auto switch bands choice changes
   Q_SIGNAL void auto_switch_bands_changed (bool auto_switch_bands);
+
+  // This signal is emitted when the user requests a manual station hop
+  Q_SIGNAL void manual_band_hop_requested (StationList::Station const& station);
 
   //
   // These signals are emitted and reflect transceiver state changes

--- a/SelfDestructMessageBox.cpp
+++ b/SelfDestructMessageBox.cpp
@@ -19,6 +19,8 @@ SelfDestructMessageBox::SelfDestructMessageBox(
 
     connect(&m_timer, &QTimer::timeout, this, &SelfDestructMessageBox::tick);
     m_timer.setInterval(1000);
+
+	connect(this, &SelfDestructMessageBox::finished, this, &SelfDestructMessageBox::stopTimer);
 }
 
 void SelfDestructMessageBox::showEvent(QShowEvent* event)
@@ -26,6 +28,11 @@ void SelfDestructMessageBox::showEvent(QShowEvent* event)
     tick();
     m_timer.start();
     QMessageBox::showEvent(event);
+}
+
+void SelfDestructMessageBox::stopTimer()
+{
+	m_timer.stop();
 }
 
 void SelfDestructMessageBox::tick(){

--- a/SelfDestructMessageBox.h
+++ b/SelfDestructMessageBox.h
@@ -26,6 +26,8 @@ public:
 
     void setShowCountdown(bool countdown){ m_show_countdown = countdown; }
 
+	void stopTimer();
+
 private slots:
     void tick();
 

--- a/StationList.cpp
+++ b/StationList.cpp
@@ -378,7 +378,7 @@ QVariant StationList::impl::data (QModelIndex const& index, int role) const
 
           case Qt::ToolTipRole:
           case Qt::AccessibleDescriptionRole:
-            item = tr ("Switch until this time");
+            item = tr ("Switch until this time\nFrequency will not return at end time.\nEnter a new line to return to original or other frequency.");
             break;
 
           case Qt::TextAlignmentRole:

--- a/StationList.cpp
+++ b/StationList.cpp
@@ -50,11 +50,21 @@ QDataStream& operator << (QDataStream& os, StationList::Station const& station)
 
 QDataStream& operator >> (QDataStream& is, StationList::Station& station)
 {
-  return is >> station.band_name_
+  is >> station.band_name_
             >> station.frequency_
             >> station.switch_at_
             >> station.switch_until_
             >> station.description_;
+
+  // Set the timezones to UTC. Will be local time when read from the saved configuration
+  station.switch_at_.setTimeZone(QTimeZone::utc());
+  station.switch_until_.setTimeZone(QTimeZone::utc());
+
+  // Convert to UTC. This is necessary because the TimeSpec needs to be Qt::UTC
+  station.switch_at_ = station.switch_at_.toUTC();
+  station.switch_until_ = station.switch_until_.toUTC();
+
+  return is;
 }
 
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1886,12 +1886,13 @@ void MainWindow::tryBandHop(){
 																  true,
 																  this);
 
-		  connect(m, &SelfDestructMessageBox::accepted, this, [this, frequency](){
-			  if(!m_config.auto_switch_bands()){
-				  return;
+		  connect(m, &SelfDestructMessageBox::finished, this, [this, m, frequency](){
+			  if(m->result() == QMessageBox::Ok)
+			  {
+				  m_bandHopped = true;
+				  setRig(frequency);
 			  }
-			  m_bandHopped = true;
-			  setRig(frequency);
+			  m->deleteLater();
 		  });
 
 		  m->show();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -599,8 +599,8 @@ MainWindow::MainWindow(QString  const & program_info,
   connect (&m_config, &Configuration::band_schedule_changed, this, [this](){
     this->m_bandHopped = true;
   });
-  connect (&m_config, &Configuration::auto_switch_bands_changed, this, [this](){
-	this->m_bandHopped = true;
+  connect (&m_config, &Configuration::auto_switch_bands_changed, this, [this](bool auto_switch_bands){
+	this->m_bandHopped = this->m_bandHopped || auto_switch_bands;
   });
   connect (&m_config, &Configuration::manual_band_hop_requested, this, &MainWindow::manualBandHop);
   connect (&m_config, &Configuration::enumerating_audio_devices, [this]()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1831,7 +1831,7 @@ void MainWindow::tryBandHop(){
   d.setDate(QDate(2000, 1, 1));
 
   QDateTime startOfDay = QDateTime(QDate(2000, 1, 1), QTime(0, 0));
-  QDateTime endOfDay = QDateTime(QDate(2000, 1, 1), QTime(23, 59));
+  QDateTime endOfDay = QDateTime(QDate(2000, 1, 1), QTime(23, 59, 59, 999));
 
   // see if we can find a needed band switch...
   foreach(auto station, stations){
@@ -1839,7 +1839,7 @@ void MainWindow::tryBandHop(){
       // and if we are switching to a different frequency than the last hop. this allows us to switch bands at that time,
       // but then later we can later switch to a different band if needed without the automatic band switching to take over
       bool inTimeRange = (
-        (station.switch_at_ <= d && d <= station.switch_until_) ||          // <- normal range, 12-16 && 6-8, evalued as 12 <= d <= 16 || 6 <= d <= 8
+        (station.switch_at_ <= d && d <= station.switch_until_) ||          // <- normal range, 12-16 && 6-8, evaluated as 12 <= d <= 16 || 6 <= d <= 8
 
         (station.switch_until_ < station.switch_at_ && (                    // <- say for a range of 12->2 & 2->12;  12->2,
              (station.switch_at_ <= d && d <= endOfDay)         ||          //    should be evaluated as 12 <= d <= 23:59 || 00:00 <= d <= 2

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1887,6 +1887,9 @@ void MainWindow::tryBandHop(){
 																  this);
 
 		  connect(m, &SelfDestructMessageBox::accepted, this, [this, frequency](){
+			  if(!m_config.auto_switch_bands()){
+				  return;
+			  }
 			  m_bandHopped = true;
 			  setRig(frequency);
 		  });
@@ -1901,7 +1904,7 @@ void MainWindow::tryBandHop(){
           connect(t, &QTimer::timeout, this, [this, hopStation, dialFreq](){
               auto message = QString("Scheduled frequency switch from %1 MHz to %2 MHz");
               message = message.arg(Radio::frequency_MHz_string(dialFreq));
-              message = message.arg(Radio::frequency_MHz_string(station.frequency_));
+              message = message.arg(Radio::frequency_MHz_string(hopStation->frequency_));
               writeNoticeTextToUI(DriftingDateTime::currentDateTimeUtc(), message);
           });
           t->start();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1834,8 +1834,8 @@ void MainWindow::tryBandHop(){
   QDateTime d = DriftingDateTime::currentDateTimeUtc();
   d.setDate(QDate(2000, 1, 1));
 
-  QDateTime startOfDay = QDateTime(QDate(2000, 1, 1), QTime(0, 0));
-  QDateTime endOfDay = QDateTime(QDate(2000, 1, 1), QTime(23, 59, 59, 999));
+  QDateTime startOfDay = QDateTime(QDate(2000, 1, 1), QTime(0, 0), QTimeZone::utc());
+  QDateTime endOfDay = QDateTime(QDate(2000, 1, 1), QTime(23, 59, 59, 999), QTimeZone::utc());
 
   StationList::Station * hopStation = nullptr;
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1923,7 +1923,7 @@ void MainWindow::tryBandHop(){
   }
 }
 
-void MainWindow::manualBandHop(const StationList::Station& station)
+void MainWindow::manualBandHop(const StationList::Station station)
 {
 	// make sure we're not transmitting
 	if(isMessageQueuedForTransmit()){

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -599,6 +599,9 @@ MainWindow::MainWindow(QString  const & program_info,
   connect (&m_config, &Configuration::band_schedule_changed, this, [this](){
     this->m_bandHopped = true;
   });
+  connect (&m_config, &Configuration::auto_switch_bands_changed, this, [this](bool auto_switch_bands){
+	this->m_bandHopped = true;
+  });
   connect (&m_config, &Configuration::enumerating_audio_devices, [this]()
   {
     showStatusMessage (tr ("Enumerating audio devices"));

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -327,7 +327,7 @@ private slots:
   void clearCallsignSelected();
   void refreshTextDisplay();
 
-  void manualBandHop(const StationList::Station &station);
+  void manualBandHop(const StationList::Station station);
 
 private:
   Q_SIGNAL void apiSetMaxConnections(int n);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -55,6 +55,7 @@
 #include "NotificationAudio.h"
 #include "ProcessThread.h"
 #include "JS8.hpp"
+#include "StationList.hpp"
 
 extern int volatile itone[JS8_NUM_SYMBOLS];   //Audio tones for all Tx symbols
 
@@ -325,6 +326,8 @@ private slots:
   void checkStartupWarnings ();
   void clearCallsignSelected();
   void refreshTextDisplay();
+
+  void manualBandHop(const StationList::Station &station);
 
 private:
   Q_SIGNAL void apiSetMaxConnections(int n);


### PR DESCRIPTION
1. Fix timezone issues with saved band windows
2. Fix timezone issues with start/end of day values in band window in-range logic
3. Handle overlapping schedule windows by always selecting the latest one
4. Reset m_bandHopped flag in MainWindow via various actions in Configuration to allow band hop dialog to launch after dialog has been cancelled by user.
5. Add ability to hop to a station from the list in settings via context menu item
6. Update context menu in station list to only show Delete option if a selection is made
7. Add logic to stop countdown timer in SelfDestructMessageBox so default button event is not emitted if box is closed by button click.