### PR TITLE
Logging time always needs UTC, fix suggested by Joe K0OG

### DIFF
--- a/logqso.ui
+++ b/logqso.ui
@@ -164,6 +164,9 @@
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
+             <property name="TimeSpec">
+              <enum>Qt::UTC</enum>
+             </property>
              <property name="displayFormat">
               <string>yyyy-MM-dd HH:mm:ss</string>
              </property>
@@ -218,6 +221,9 @@
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
+             </property>
+             <property name="TimeSpec">
+              <enum>Qt::UTC</enum>
              </property>
              <property name="displayFormat">
               <string>yyyy-MM-dd HH:mm:ss</string>


### PR DESCRIPTION
See https://github.com/js8call/js8call/issues/37#issuecomment-3132750504 .

Fixes #37.