### PR TITLE
Make it easier to understand the mode letters in ALL.TXT.

### DIFF
--- a/decodedtext.cpp
+++ b/decodedtext.cpp
@@ -30,11 +30,11 @@ namespace
   {
     switch (submode)
     {
-      case 0:  return 'A';
-      case 1:  return 'B';
-      case 2:  return 'C';
-      case 4:  return 'E';
-      case 8:  return 'I';
+      case Varicode::SubmodeType::JS8CallNormal:  return 'A';
+      case Varicode::SubmodeType::JS8CallFast:    return 'B';
+      case Varicode::SubmodeType::JS8CallTurbo:   return 'C';
+      case Varicode::SubmodeType::JS8CallSlow:    return 'E';
+      case Varicode::SubmodeType::JS8CallUltra:   return 'I';
       default: return '~';
     }
   }


### PR DESCRIPTION
There is no public information known to me available which mode letters in `ALL.TXT` correspond to which mode. Of course, with the exception of the source code.

Extracting this information from the source code is somewhat hard. Certainly harder than it needs to be.

This pull request improves the situation.

It also improves overall code quality, as it moves towards "single source of truth" regarding which number corresponds to which mode.