### PR TITLE
Small interface glitch QEdit ↔ TransmitTextEdit

### DIFF
--- a/TransmitTextEdit.cpp
+++ b/TransmitTextEdit.cpp
@@ -123,9 +123,10 @@ QString TransmitTextEdit::toPlainText() const {
 
 // override
 void TransmitTextEdit::setPlainText(const QString &text){
-    QTextEdit::setPlainText(text);
     m_textSent.clear();
     m_sent = 0;
+    // Do this last, as it may trigger events that, during processing, like to see m_textSent and m_sent reset.
+    QTextEdit::setPlainText(text);
 }
 
 //
@@ -185,9 +186,10 @@ void TransmitTextEdit::setFont(QFont f, QColor fg, QColor bg){
 
 // override
 void TransmitTextEdit::clear(){
-    QTextEdit::clear();
     m_textSent.clear();
     m_sent = 0;
+    // Do this last, as it may trigger events that, during processing, like to see m_textSent and m_sent reset.
+    QTextEdit::clear();
 }
 
 void TransmitTextEdit::setProtected(bool protect){

--- a/TransmitTextEdit.cpp
+++ b/TransmitTextEdit.cpp
@@ -100,8 +100,11 @@ TransmitTextEdit::TransmitTextEdit(QWidget *parent):
 }
 
 void TransmitTextEdit::setCharsSent(int n){
-    // never can send more than the document length
-    n = qMin(n, document()->characterCount());
+    // Never can send more than the document length.
+    // From the QTextDocument::characterCount() documentation:
+    // As a QTextDocument always contains at least one QChar::ParagraphSeparator, this method will return at least 1.
+    // We do not send that paragraph separator.
+    n = qMin(n, document()->characterCount()-1);
 
     // update sent display
     auto c = textCursor();


### PR DESCRIPTION
I did a bit of (print-) debugging and noticed that, at the end of a transmission of text that had been typed in, `TransmitTextEdit::highlightCharsSent()` was called with the document text already cleared, but `m_sent` still at the original message length. This fixes this glitch by clearing `m_sent` and `m_textSent` **first**, before calling the base class's `QTextEdit`'s methods. The theory is that the latter, via events, end up calling `highlightCharsSent()`, and possibly other methods that prefer `m_`-type attributes and text to be in sync.

Secondly, `document()->characterCount()` returns a value that is consistently 1 higher than we think. This is due to a paragraph separator character that's always present even when the document has been freshly cleared. This character is utterly ignored by our code.