### PR TITLE
Include next available message id in message responses

### DIFF
--- a/Inbox.cpp
+++ b/Inbox.cpp
@@ -306,6 +306,59 @@ bool Inbox::del(int key){
     return true;
 }
 
+int Inbox::getLookaheadMessageIdForCallsign(const QString &callsign, int afterMsgId){
+	if(!isOpen()){
+		return -1;
+	}
+
+	const char* sql = "SELECT inbox_v1.id, inbox_v1.blob FROM inbox_v1 "
+					  "WHERE inbox_v1.id > ? "
+					  "AND json_extract(blob, '$.type') = 'STORE' "
+					  "AND json_extract(blob, '$.params.TO') LIKE ? "
+					  "ORDER BY inbox_v1.id ASC "
+					  "LIMIT ? OFFSET ?;";
+
+	sqlite3_stmt *stmt;
+	int rc = sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr);
+	if(rc != SQLITE_OK){
+		return -1;
+	}
+
+	auto c8 = callsign.toLocal8Bit();
+
+	rc = sqlite3_bind_int(stmt, 1, afterMsgId);
+	rc = sqlite3_bind_text(stmt, 2, c8.data(), -1, nullptr);
+	rc = sqlite3_bind_int(stmt, 3, 10);
+	rc = sqlite3_bind_int(stmt, 4, 0);
+
+	//qDebug() << "exec " << sqlite3_expanded_sql(stmt);
+
+	int next_id = -1;
+	while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+		Message m;
+
+		int i = sqlite3_column_int(stmt, 0);
+
+		auto msg = QByteArray((const char*)sqlite3_column_text(stmt, 1), sqlite3_column_bytes(stmt, 1));
+
+		m = Message::fromJson(msg);
+
+		auto params = m.params();
+		auto text = params.value("TEXT").toString().trimmed();
+		if(!text.isEmpty()){
+			next_id = i;
+			break;
+		}
+	}
+
+	rc = sqlite3_finalize(stmt);
+	if(rc != SQLITE_OK){
+		return -1;
+	}
+
+	return next_id;
+}
+
 /**
  * High-Level Interface
  **/
@@ -452,6 +505,70 @@ int Inbox::getNextGroupMessageIdForCallsign(const QString &group_name, const QSt
 	rc = sqlite3_bind_int(stmt, 5, 0);
 
 	//qDebug() << "exec " << sqlite3_expanded_sql(stmt);
+
+	int next_id = -1;
+	while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+		Message m;
+
+		int i = sqlite3_column_int(stmt, 0);
+
+		auto msg = QByteArray((const char*)sqlite3_column_text(stmt, 1), sqlite3_column_bytes(stmt, 1));
+
+		m = Message::fromJson(msg);
+
+		auto params = m.params();
+		auto text = params.value("TEXT").toString().trimmed();
+		if(!text.isEmpty()){
+			next_id = i;
+			break;
+		}
+	}
+
+	rc = sqlite3_finalize(stmt);
+	if(rc != SQLITE_OK){
+		return -1;
+	}
+
+	return next_id;
+}
+
+int Inbox::getLookaheadGroupMessageIdForCallsign(const QString &group_name, const QString &callsign, int afterMsgId){
+	if(!isOpen()){
+		return -1;
+	}
+
+	const char* sql = "SELECT inbox_v1.id, inbox_v1.blob FROM inbox_v1 "
+					  "LEFT JOIN inbox_group_recip_v1 ON (inbox_group_recip_v1.msg_id=inbox_v1.id AND inbox_group_recip_v1.callsign = ?) "
+					  "WHERE inbox_v1.id > ? "
+					  "AND json_extract(blob, '$.type') = 'STORE' "
+					  "AND json_extract(blob, '$.params.TO') LIKE ? "
+					  "AND json_extract(blob, '$.params.UTC') > ? "
+					  "AND inbox_group_recip_v1.id IS NULL "
+					  "ORDER BY inbox_v1.id ASC "
+					  "LIMIT ? OFFSET ?;";
+
+	sqlite3_stmt *stmt;
+	int rc = sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr);
+	if(rc != SQLITE_OK){
+		return -1;
+	}
+
+	auto c8 = callsign.toLocal8Bit();
+	auto g8 = group_name.toLocal8Bit();
+
+	// Set a floor or 48 hours for group message retrieval
+	// TODO: date formatting with the "yyyy-MM-dd HH:mm:ss" string happens elsewhere as well, centralize
+	// TODO: possibly make the date floor configurable
+	auto d8 = DriftingDateTime::currentDateTimeUtc().addDays(-2).toString("yyyy-MM-dd HH:mm:ss").toLocal8Bit();
+
+	rc = sqlite3_bind_text(stmt, 1, c8.data(), -1, nullptr);
+	rc = sqlite3_bind_int(stmt, 2, afterMsgId);
+	rc = sqlite3_bind_text(stmt, 3, g8.data(), -1, nullptr);
+	rc = sqlite3_bind_text(stmt, 4, d8.data(), -1, nullptr);
+	rc = sqlite3_bind_int(stmt, 5, 10);
+	rc = sqlite3_bind_int(stmt, 6, 0);
+
+	qDebug() << "exec " << sqlite3_expanded_sql(stmt);
 
 	int next_id = -1;
 	while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {

--- a/Inbox.h
+++ b/Inbox.h
@@ -36,9 +36,11 @@ public:
     // High-Level Interface
     int countUnreadFrom(QString from);
     QPair<int, Message> firstUnreadFrom(QString from);
+	int getLookaheadMessageIdForCallsign(const QString &callsign, int afterMsgId);
 
 	QMap<QString, int> getGroupMessageCounts();
 	int getNextGroupMessageIdForCallsign(const QString &group_name, const QString &callsign);
+	int getLookaheadGroupMessageIdForCallsign(const QString &group_name, const QString &callsign, int afterMsgId);
 	bool markGroupMsgDeliveredForCallsign(int msgId, QString callsign);
 
 signals:

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1729,6 +1729,20 @@ void MainWindow::initializeGroupMessageDummyData()
 
 	processCommandActivity();
 
+	dt = DriftingDateTime::currentDateTimeUtc().addSecs(-150);
+
+	CommandDetail cmd1 = {};
+	cmd1.cmd = " MSG TO:";
+	cmd1.from = "KN4CRD";
+	cmd1.to = "@GROUP42";
+	cmd1.utcTimestamp = dt;
+	cmd1.submode = Varicode::JS8CallNormal;
+	cmd1.text = "@GROUP42 ANOTHER TEST MESSAGE TO GROUP";
+
+	m_rxCommandQueue.append(cmd1);
+
+	processCommandActivity();
+
 	CommandDetail cmd2 = {};
 	cmd2.cmd = " QUERY MSGS";
 	cmd2.from = "W1AW";
@@ -1759,6 +1773,67 @@ void MainWindow::initializeGroupMessageDummyData()
 	cmd3.text = textString.c_str();
 
 	m_rxCommandQueue.append(cmd3);
+
+	processCommandActivity();
+
+	dt = DriftingDateTime::currentDateTimeUtc().addSecs(-300);
+
+	CommandDetail cmd4 = {};
+	cmd4.cmd = " MSG TO:";
+	cmd4.from = "KN4CRD";
+	cmd4.to = "K4RWR";
+	cmd4.utcTimestamp = dt;
+	cmd4.submode = Varicode::JS8CallNormal;
+	cmd4.text = "W1AW TEST MESSAGE TO STATION";
+
+	m_rxCommandQueue.append(cmd4);
+
+	processCommandActivity();
+
+	dt = DriftingDateTime::currentDateTimeUtc().addSecs(-150);
+
+	CommandDetail cmd5 = {};
+	cmd5.cmd = " MSG TO:";
+	cmd5.from = "KN4CRD";
+	cmd5.to = "K4RWR";
+	cmd5.utcTimestamp = dt;
+	cmd5.submode = Varicode::JS8CallNormal;
+	cmd5.text = "W1AW ANOTHER TEST MESSAGE TO STATION";
+
+	m_rxCommandQueue.append(cmd5);
+
+	processCommandActivity();
+
+	CommandDetail cmd6 = {};
+	cmd6.cmd = " QUERY MSGS";
+	cmd6.from = "W1AW";
+	cmd6.to = "K4RWR";
+	cmd6.utcTimestamp = DriftingDateTime::currentDateTimeUtc();
+	cmd6.submode = Varicode::JS8CallNormal;
+
+	m_rxCommandQueue.append(cmd6);
+
+	processCommandActivity();
+
+	mid = getNextMessageIdForCallsign("W1AW");
+
+	qDebug() << "Testing group messaging";
+	qDebug() << "Test message ID: " << mid;
+
+	textString = "MSG ";
+	textString += std::to_string(mid);
+
+	qDebug() << "Text string: " << textString.c_str();
+
+	CommandDetail cmd7 = {};
+	cmd7.cmd = " QUERY";
+	cmd7.from = "W1AW";
+	cmd7.to = "K4RWR";
+	cmd7.utcTimestamp = DriftingDateTime::currentDateTimeUtc();
+	cmd7.submode = Varicode::JS8CallNormal;
+	cmd7.text = textString.c_str();
+
+	m_rxCommandQueue.append(cmd7);
 
 	processCommandActivity();
 
@@ -9202,11 +9277,27 @@ void MainWindow::processCommandActivity() {
 					};
 				}
 
+				auto lookaheadMid = getLookaheadMessageIdForCallsign(who, mid);
+				if(lookaheadMid == -1 && isGroupMsg){
+					lookaheadMid = getLookaheadGroupMessageIdForCallsign(d.to, who, mid);
+				}
+
                 // and reply
-                reply = QString("%1 MSG %2 FROM %3");
-                reply = reply.arg(replyPath);
-                reply = reply.arg(text);
-                reply = reply.arg(from);
+				if(lookaheadMid != -1)
+				{
+					reply = QString("%1 MSG %2 FROM %3 NEXT MSG ID %4");
+					reply = reply.arg(replyPath);
+					reply = reply.arg(text);
+					reply = reply.arg(from);
+					reply = reply.arg(lookaheadMid);
+				}
+				else
+				{
+					reply = QString("%1 MSG %2 FROM %3");
+					reply = reply.arg(replyPath);
+					reply = reply.arg(text);
+					reply = reply.arg(from);
+				}
             }
         }
 
@@ -9490,15 +9581,61 @@ int MainWindow::getNextMessageIdForCallsign(QString callsign){
     return -1;
 }
 
-// Facade for Inbox::getNextGroupMessageIdForCallsign
-int MainWindow::getNextGroupMessageIdForCallsign(QString group_name, QString callsign)
-{
-	Inbox inbox(inboxPath());
+int MainWindow::getLookaheadMessageIdForCallsign(QString callsign, int msgId){
+	auto inbox = Inbox(inboxPath());
 	if(!inbox.open()){
 		return -1;
 	}
 
+	int mid = inbox.getLookaheadMessageIdForCallsign(callsign, msgId);
+
+	if(mid == -1)
+	{
+		mid = inbox.getLookaheadMessageIdForCallsign(Radio::base_callsign(callsign), msgId);
+	}
+
+	if(mid != -1)
+	{
+		return mid;
+	}
+
+	return -1;
+}
+
+// Facade for Inbox::getNextGroupMessageIdForCallsign
+int MainWindow::getNextGroupMessageIdForCallsign(QString group_name, QString callsign)
+{
+	Inbox inbox(inboxPath());
+	if(!inbox.open())
+	{
+		return -1;
+	}
+
 	return inbox.getNextGroupMessageIdForCallsign(group_name, callsign);
+}
+
+// Facade for Inbox::getLookaheadGroupMessageIdForCallsign
+int MainWindow::getLookaheadGroupMessageIdForCallsign(QString group_name, QString callsign, int afterMsgId)
+{
+	Inbox inbox(inboxPath());
+	if(!inbox.open())
+	{
+		return -1;
+	}
+
+	int mid = inbox.getLookaheadGroupMessageIdForCallsign(group_name, callsign, afterMsgId);
+
+	if(mid == -1)
+	{
+		mid = inbox.getLookaheadGroupMessageIdForCallsign(group_name, Radio::base_callsign(callsign), afterMsgId);
+	}
+
+	if(mid != -1)
+	{
+		return mid;
+	}
+
+	return -1;
 }
 
 // Facade for Inbox::markGroupMsgDeliveredForCallsign

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -767,7 +767,9 @@ private:
   int addCommandToMyInbox(CommandDetail d);
   int addCommandToStorage(QString type, CommandDetail d);
   int getNextMessageIdForCallsign(QString callsign);
+  int getLookaheadMessageIdForCallsign(QString callsign, int afterMsgId);
   int getNextGroupMessageIdForCallsign(QString group_name, QString callsign);
+  int getLookaheadGroupMessageIdForCallsign(QString group_name, QString callsign, int afterMsgId);
   bool markGroupMsgDeliveredForCallsign(int msgId, QString callsign);
   bool markMsgDelivered(int mid, Message msg);
   QStringList parseRelayPathCallsigns(QString from, QString text);


### PR DESCRIPTION
Addresses issue [#29](https://github.com/js8call/js8call/issues/29)

Append "NEXT MSG ID #" to the message response if there is another message available. This is a classic "linked list" or "forward pointer" pattern that's commonly used in messaging systems to efficiently traverse a list of available messages.